### PR TITLE
Mark arrayEquals parameters as readonly array

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "scripts": {
     "clean": "rimraf dist",
-    "prepare": "npm run clean && tsc",
+    "build": "tsc -p .",
+    "prepare": "npm run clean && npm run build",
     "lint": "tslint -c ./tslint.json 'src/**/*.ts' --project ./tsconfig.json",
     "test": "jest"
   },

--- a/src/arrays.ts
+++ b/src/arrays.ts
@@ -59,7 +59,7 @@ export const partition = <T>(array: ReadonlyArray<T>, partitionFn: PartitionFunc
 
 type UniqueIdFunction<T> = (element: T) => string;
 type MergeFunction<T> = (a: T, b: T) => T;
-const defaultUniqueMergeFunction = <T>(a: T, b: T) => a;
+const defaultUniqueMergeFunction = <T>(a: T) => a;
 export const unique = <T>(
     array: ReadonlyArray<T>,
     uniqueFn: UniqueIdFunction<T>,

--- a/src/arrays.ts
+++ b/src/arrays.ts
@@ -72,11 +72,15 @@ export const unique = <T>(
         .map((sameItems: ReadonlyArray<T>) => sameItems.reduce(mergeFn));
 };
 
-export const arrayEquals = <T>(a: readonly T[], b: readonly T[], cmp: (a: T, b: T) => boolean = (x: T, y: T) => x === y): boolean => {
+export const arrayEquals = <T>(
+    a: readonly T[],
+    b: readonly T[],
+    cmp: (a: T, b: T) => boolean = defaultCompareFunction,
+): boolean => {
     if (a.length !== b.length) {
         return false;
     }
-    for (let i = a.length - 1; i >= 0; i--) {
+    for (let i = a.length - 1; i >= 0; i -= 1) {
         if (!cmp(a[i], b[i])) {
             return false;
         }
@@ -86,6 +90,7 @@ export const arrayEquals = <T>(a: readonly T[], b: readonly T[], cmp: (a: T, b: 
 };
 
 type CompareFunction<T> = (a: T, b: T) => boolean;
+// tslint:disable-next-line: strict-comparisons
 const defaultCompareFunction = <T>(a: T, b: T) => a === b;
 
 export const arrayIntersect = <T>(

--- a/src/arrays.ts
+++ b/src/arrays.ts
@@ -72,7 +72,7 @@ export const unique = <T>(
         .map((sameItems: ReadonlyArray<T>) => sameItems.reduce(mergeFn));
 };
 
-export const arrayEquals = <T>(a: T[], b: T[], cmp: (a: T, b: T) => boolean = (x: T, y: T) => x === y): boolean => {
+export const arrayEquals = <T>(a: readonly T[], b: readonly T[], cmp: (a: T, b: T) => boolean = (x: T, y: T) => x === y): boolean => {
     if (a.length !== b.length) {
         return false;
     }

--- a/src/arrays.ts
+++ b/src/arrays.ts
@@ -1,7 +1,7 @@
 export type ReadonlyArray2D<T> = ReadonlyArray<ReadonlyArray<T>>;
 export const emptyArray = <T>(): ReadonlyArray<T> => [];
 
-export const asImmutable = <T>(array: T[]): ReadonlyArray<T> => array as ReadonlyArray<T>;
+export const asImmutable = <T>(array: T[]): ReadonlyArray<T> => array.slice() as ReadonlyArray<T>;
 
 export const flatten = <T>(toFlatten: ReadonlyArray2D<T>): T[] => ([] as T[]).concat(...toFlatten);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "./dist",
+        // Emit options
         "target": "es2015",
         "module": "commonjs",
         "moduleResolution": "node",
@@ -8,10 +9,17 @@
         "declaration": true,
         "sourceMap": true,
         "esModuleInterop": true,
+        "noEmitOnError": true,
+        // Compile options
+        "strict": true,
         "noImplicitAny": true,
-        "noImplicitUseStrict": true,
+        "noUnusedParameters": true,
+        "noImplicitReturns": true,
+        "noImplicitThis": true,
+        "importsNotUsedAsValues": "error",
+        "stripInternal": true,
+        "alwaysStrict": true,
         "preserveConstEnums": true,
-        "strictNullChecks": true
     },
     "include": [
         "src"

--- a/tslint.json
+++ b/tslint.json
@@ -1,3 +1,6 @@
 {
-    "extends": "tslint:recommended"
+    "extends": "tslint:all",
+    "rules": {
+        "typedef": false
+    }
 }


### PR DESCRIPTION
If a function does not modify arrays that it takes as arguments, the parameters should be marked as readonly array.
This enables callers to pass both readonly arrays and arrays as parameters.

Also fix `asImmutable()` so it actually creates an immutable copy of the array